### PR TITLE
Switch to AWS docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16 as builder
+FROM public.ecr.aws/docker/library/node:16 as builder
 
 COPY package.json yarn.lock ./
 RUN yarn


### PR DESCRIPTION
Switch to AWS docker image to avoid dockerhub daily pull limits